### PR TITLE
Fix: #38 missing 'color: inherit' in index.css

### DIFF
--- a/msal_streamlit_authentication/frontend/src/index.css
+++ b/msal_streamlit_authentication/frontend/src/index.css
@@ -16,6 +16,7 @@ button {
   font-size: inherit;
   font-weight: inherit;
   font-family: inherit;
+  color: inherit;
   background-color: inherit;
   cursor: pointer;
 }


### PR DESCRIPTION
The login button blends in to the background with a similar color when using Dark themes as a personalization option in Windows settings. This fixes it.